### PR TITLE
removed trailing api comma

### DIFF
--- a/spint/api.py
+++ b/spint/api.py
@@ -1,3 +1,3 @@
-from .gravity import BaseGravity, Gravity, Production, Attraction, Doubly,
+from .gravity import BaseGravity, Gravity, Production, Attraction, Doubly
 from .dispersion import phi_disp, alpha_disp
 


### PR DESCRIPTION
@ljwolf removed trailing api comma as per [issue 10](https://github.com/pysal/spint/issues/10)