### PR TITLE
Move np.random.seed into individual testing cases for test_vec_SA.py

### DIFF
--- a/spint/tests/test_vec_SA.py
+++ b/spint/tests/test_vec_SA.py
@@ -7,7 +7,6 @@ __author__ = 'Taylor Oshan tayoshan@gmail.com'
 
 import unittest
 import numpy as np
-np.random.seed(1)
 from libpysal.weights.distance import DistanceBand
 from ..vec_SA import VecMoran
 
@@ -31,12 +30,14 @@ class TestVecMoran(unittest.TestCase):
             threshold=9999,
             alpha=-1.5,
             binary=False)
+        np.random.seed(1)
         vmo = VecMoran(self.vecs, wo, focus='origin', rand='A')
         self.assertAlmostEquals(vmo.I, 0.645944594367)
-        self.assertAlmostEquals(vmo.p_z_sim, 0.099549579548)
+        self.assertAlmostEquals(vmo.p_z_sim, 0.03898650733809228)
 
     def test_dest_focused_A(self):
         wd = DistanceBand(self.dests, threshold=9999, alpha=-1.5, binary=False)
+        np.random.seed(1)
         vmd = VecMoran(self.vecs, wd, focus='destination', rand='A')
         self.assertAlmostEquals(vmd.I, -0.764603695022)
         self.assertAlmostEquals(vmd.p_z_sim, 0.149472673677)
@@ -47,15 +48,17 @@ class TestVecMoran(unittest.TestCase):
             threshold=9999,
             alpha=-1.5,
             binary=False)
+        np.random.seed(1)
         vmo = VecMoran(self.vecs, wo, focus='origin', rand='B')
         self.assertAlmostEquals(vmo.I, 0.645944594367)
-        self.assertAlmostEquals(vmo.p_z_sim, 0.071427063787951814)
+        self.assertAlmostEquals(vmo.p_z_sim, 0.02944612633233532)
 
     def test_dest_focused_B(self):
         wd = DistanceBand(self.dests, threshold=9999, alpha=-1.5, binary=False)
+        np.random.seed(1)
         vmd = VecMoran(self.vecs, wd, focus='destination', rand='B')
         self.assertAlmostEquals(vmd.I, -0.764603695022)
-        self.assertAlmostEquals(vmd.p_z_sim, 0.086894261015806051)
+        self.assertAlmostEquals(vmd.p_z_sim, 0.12411761124197379)
 
 
 if __name__ == '__main__':

--- a/spint/vec_SA.py
+++ b/spint/vec_SA.py
@@ -131,14 +131,14 @@ class VecMoran:
     --------
     >>> import numpy as np
     >>> np.random.seed(1)
-    >>> from pysal_core.weights import DistanceBand
+    >>> from libpysal.weights import DistanceBand
     >>> from spint.vec_SA import VecMoran
     >>> vecs = np.array([[1, 55, 60, 100, 500],
-    >>>                 [2, 60, 55, 105, 501],
-    >>>                 [3, 500, 55, 155, 500],
-    >>>                 [4, 505, 60, 160, 500],
-    >>>                 [5, 105, 950, 105, 500],
-    >>>                 [6, 155, 950, 155, 499]])
+    ...                  [2, 60, 55, 105, 501],
+    ...                  [3, 500, 55, 155, 500],
+    ...                  [4, 505, 60, 160, 500],
+    ...                  [5, 105, 950, 105, 500],
+    ...                  [6, 155, 950, 155, 499]])
     >>> origins = vecs[:, 1:3]
     >>> dests = vecs[:, 3:5]
     >>> wo = DistanceBand(origins, threshold=9999, alpha=-1.5, binary=False)
@@ -148,25 +148,25 @@ class VecMoran:
     >>> vmo = VecMoran(vecs, wo, focus='origin', rand='A')
     >>> vmd = VecMoran(vecs, wd, focus='destination', rand='A')
     >>> vmo.I
-    -0.764603695022
+    0.6459445943670211
     >>> vmo.p_z_sim
-    0.99549579548
-    >>>  vmd.I
-    0.645944594367
-    >>>  vmd.p_z_sim
-    0.1494726733677
+    0.03898650733809228
+    >>> vmd.I
+    -0.7646036950223406
+    >>> vmd.p_z_sim
+    0.11275129553163704
 
     #randomization technique B
     >>> vmo = VecMoran(vecs, wo, focus='origin', rand='B')
-    >>> vmd = VecMoran(vecs, wd, foucs='destination', rand='B')
+    >>> vmd = VecMoran(vecs, wd, focus='destination', rand='B')
     >>> vmo.I
-    -0.764603695022
+    0.6459445943670211
     >>> vmo.p_z_sim
-    0.071427063787951814
-    >>>  vmd.I
-    0.645944594367
-    >>>  vmd.p_z_sim
-    0.086894261015806051
+    0.05087923006558356
+    >>> vmd.I
+    -0.7646036950223406
+    >>> vmd.p_z_sim
+    0.1468368983650693
 
     """
 


### PR DESCRIPTION
[test_vec_SA.py](https://github.com/pysal/spint/blob/master/spint/tests/test_vec_SA.py) passes locally and on travis testing for spint, but [fails on the meta package travis testing](https://travis-ci.org/sjsrey/pysal/jobs/473236988). After a deep dive, I think the failure is related to the permutation/randomization-based inference `p_z_sim`. More specifically, the reason for the failure lies in where np.random.seed (to seed the pseudo-random number generator) is placed. Currently, it is placed [at the beginning of test_vec_SA.py where all the relevant packages are imported](https://github.com/pysal/spint/blob/master/spint/tests/test_vec_SA.py#L10). I am guessing that meta package travis testing does not honor this though the local testing and subpackage travis testing do. Moving np.random.seed into individual testing cases similar to [the giddy testing case](https://github.com/pysal/giddy/blob/master/giddy/tests/test_markov.py#L95) should resolve the issue in meta package travis testing. 